### PR TITLE
Update bitbucket api path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ BitBucket repository with a `releases` as its main branch, as described in [this
   
   Note: Do not check this file into version control! 
   
-  Check [this blogpost](http://localhost:4000/blog/2015/08/13/artifactory2/) password to securely provide your username and password.
+  Check [this blogpost](https://jeroenmols.com/blog/2015/08/13/artifactory2/) password to securely provide your username and password.
 
 4. Run the following command to upload a version to your Maven repository.
 

--- a/publish-bitbucket.gradle
+++ b/publish-bitbucket.gradle
@@ -38,7 +38,7 @@ task lookForArtifacts {
     doLast {
         def artifactName = ARTIFACT_NAME + '-' + ARTIFACT_VERSION + '.aar'
         def artifactPath = ARTIFACT_PACKAGE.replace(".", "/") + "/" + ARTIFACT_NAME + "/" + ARTIFACT_VERSION + "/" + artifactName
-        def repositoryUrl = 'https://api.bitbucket.org/2.0/repositories/' + COMPANY + '/' + REPOSITORY_NAME + '/raw/releases/' + artifactPath
+        def repositoryUrl = 'https://api.bitbucket.org/2.0/repositories/' + COMPANY + '/' + REPOSITORY_NAME + '/src/releases/' + artifactPath
 
         println("")
         println("Checking if artifact already exists: " + artifactName)


### PR DESCRIPTION
Hi @JeroenMols 

The raw path didn't work for me and couldn't find it in the bitbucket api v2.0 documentation. So i changed for '.../src/releases/'.

The src path can be found here: https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/src/%7Bnode%7D/%7Bpath%7D

Fixed the blogspot url